### PR TITLE
Some modernization

### DIFF
--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -41,7 +41,7 @@ library
     Language.Bash.Parse.Internal
 
   build-depends:
-    base         >= 4   && < 5,
+    base         >= 4.8 && < 5,
     parsec       >= 3.0 && < 4.0,
     pretty       >= 1.0 && < 2.0,
     transformers >= 0.2 && < 0.4

--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -44,7 +44,7 @@ library
     base         >= 4.8 && < 5,
     parsec       >= 3.0 && < 4.0,
     pretty       >= 1.0 && < 2.0,
-    transformers >= 0.2 && < 0.4
+    transformers >= 0.2 && < 0.5
 
   ghc-options: -Wall
 

--- a/src/Language/Bash/Cond.hs
+++ b/src/Language/Bash/Cond.hs
@@ -15,8 +15,6 @@ module Language.Bash.Cond
 import Prelude                hiding (negate)
 
 import Control.Applicative
-import Data.Foldable          (Foldable)
-import Data.Traversable       (Traversable)
 import Text.Parsec            hiding ((<|>), token)
 import Text.Parsec.Expr       hiding (Operator)
 import Text.PrettyPrint       hiding (parens)

--- a/src/Language/Bash/Cond.hs
+++ b/src/Language/Bash/Cond.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-    DeriveFoldable
+    DeriveDataTypeable
+  , DeriveFoldable
   , DeriveFunctor
   , DeriveTraversable
   , OverloadedStrings
@@ -15,6 +16,8 @@ module Language.Bash.Cond
 import Prelude                hiding (negate)
 
 import Control.Applicative
+import Data.Data              (Data)
+import Data.Typeable          (Typeable)
 import Text.Parsec            hiding ((<|>), token)
 import Text.Parsec.Expr       hiding (Operator)
 import Text.PrettyPrint       hiding (parens)
@@ -29,7 +32,7 @@ data CondExpr a
     | Not (CondExpr a)
     | And (CondExpr a) (CondExpr a)
     | Or (CondExpr a) (CondExpr a)
-    deriving (Eq, Read, Show, Functor, Foldable, Traversable)
+    deriving (Data, Eq, Read, Show, Typeable, Functor, Foldable, Traversable)
 
 instance Pretty a => Pretty (CondExpr a) where
     pretty = go (0 :: Int)
@@ -68,7 +71,7 @@ data UnaryOp
     | Varname        -- ^ @-v@
     | ZeroString     -- ^ @-z@
     | NonzeroString  -- ^ @-n /string/@ or @/string/@
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator UnaryOp where
     operatorTable =
@@ -97,7 +100,7 @@ data BinaryOp
     | ArithLE    -- ^ @-le@
     | ArithGT    -- ^ @-gt@
     | ArithGE    -- ^ @-ge@
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator BinaryOp where
     operatorTable =

--- a/src/Language/Bash/Expand.hs
+++ b/src/Language/Bash/Expand.hs
@@ -7,10 +7,11 @@ module Language.Bash.Expand
     , splitWord
     ) where
 
+import Prelude hiding (Word)
+
 import Control.Applicative
 import Control.Monad
 import Data.Char
-import Data.Traversable
 import Text.Parsec.Combinator hiding (optional, manyTill)
 import Text.Parsec.Prim       hiding ((<|>), many, token)
 import Text.Parsec.String     ()

--- a/src/Language/Bash/Parse/Internal.hs
+++ b/src/Language/Bash/Parse/Internal.hs
@@ -36,6 +36,8 @@ module Language.Bash.Parse.Internal
     , heredocWord
     ) where
 
+import Prelude hiding (Word)
+
 import           Control.Applicative
 import           Control.Monad
 import           Data.Function

--- a/src/Language/Bash/Parse/Word.hs
+++ b/src/Language/Bash/Parse/Word.hs
@@ -11,6 +11,8 @@ module Language.Bash.Parse.Word
     , operator
     ) where
 
+import Prelude hiding (Word)
+
 import           Control.Applicative
 import           Control.Monad
 import           Data.Char

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -25,6 +25,8 @@ module Language.Bash.Syntax
     , RValue(..)
     ) where
 
+import Prelude hiding (Word)
+
 import Text.PrettyPrint
 
 import Language.Bash.Cond     (CondExpr)

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable, OverloadedStrings, RecordWildCards #-}
 -- | Shell script types.
 module Language.Bash.Syntax
     (
@@ -27,6 +27,8 @@ module Language.Bash.Syntax
 
 import Prelude hiding (Word)
 
+import Data.Data        (Data)
+import Data.Typeable    (Typeable)
 import Text.PrettyPrint
 
 import Language.Bash.Cond     (CondExpr)
@@ -44,7 +46,7 @@ doDone a = "do" $+$ indent a $+$ "done"
 
 -- | A Bash command with redirections.
 data Command = Command ShellCommand [Redir]
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Command where
     pretty (Command c rs) = pretty c <+> pretty rs
@@ -85,7 +87,7 @@ data ShellCommand
     | Until List List
       -- | A @while@ command.
     | While List List
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty ShellCommand where
     pretty (SimpleCommand as ws)  = pretty as <+> pretty ws
@@ -123,7 +125,7 @@ instance Pretty ShellCommand where
 data WordList
     = Args
     | WordList [Word]
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty WordList where
     pretty Args          = empty
@@ -131,7 +133,7 @@ instance Pretty WordList where
 
 -- | A single case clause.
 data CaseClause = CaseClause [Word] List CaseTerm
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty CaseClause where
     pretty (CaseClause ps l term) =
@@ -144,7 +146,7 @@ data CaseTerm
     = Break        -- ^ @;;@
     | FallThrough  -- ^ @;&@
     | Continue     -- ^ @;;&@
-    deriving (Eq, Ord, Read, Show, Bounded, Enum)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Bounded, Enum)
 
 instance Operator CaseTerm where
     operatorTable = zip [minBound .. maxBound] [";;", ";&", ";;&"]
@@ -176,7 +178,7 @@ data Redir
           -- and command substitutions take place.
         , hereDocument       :: Word
         }
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Redir where
     pretty Redir{..} =
@@ -199,7 +201,7 @@ data IODesc
     = IONumber Int
       -- | A variable @{/varname/}@ to allocate a file descriptor for.
     | IOVar String
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty IODesc where
     pretty (IONumber n) = int n
@@ -217,7 +219,7 @@ data RedirOp
     | InAnd       -- ^ @\<&@
     | OutAnd      -- ^ @\>&@
     | InOut       -- ^ @\<\>@
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator RedirOp where
     operatorTable = zip [minBound .. maxBound]
@@ -230,7 +232,7 @@ instance Pretty RedirOp where
 data HeredocOp
     = Here       -- ^ @\<\<@
     | HereStrip  -- ^ @\<\<-@
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator HeredocOp where
     operatorTable = zip [Here, HereStrip] ["<<", "<<-"]
@@ -240,14 +242,14 @@ instance Pretty HeredocOp where
 
 -- | A compound list of statements.
 newtype List = List [Statement]
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty List where
     pretty (List as) = pretty as
 
 -- | A single statement in a list.
 data Statement = Statement AndOr ListTerm
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Statement where
     pretty (Statement l Sequential)   = pretty l <> ";"
@@ -262,7 +264,7 @@ instance Pretty Statement where
 data ListTerm
     = Sequential    -- ^ @;@
     | Asynchronous  -- ^ @&@
-    deriving (Eq, Ord, Read, Show, Bounded, Enum)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Bounded, Enum)
 
 instance Operator ListTerm where
     operatorTable =
@@ -282,7 +284,7 @@ data AndOr
     | And Pipeline AndOr
       -- | A @||@ construct.
     | Or Pipeline AndOr
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty AndOr where
     pretty (Last p)  = pretty p
@@ -301,7 +303,7 @@ data Pipeline = Pipeline
       -- @command1 |& command2@ is treated as a shorthand for
       -- @command1 2>&1 | command2@.
     , commands   :: [Command]
-    } deriving (Eq, Read, Show)
+    } deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Pipeline where
     pretty Pipeline{..} =
@@ -312,7 +314,7 @@ instance Pretty Pipeline where
 
 -- | An assignment.
 data Assign = Assign Parameter AssignOp RValue
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Assign where
     pretty (Assign lhs op rhs) = pretty lhs <> pretty op <> pretty rhs
@@ -321,7 +323,7 @@ instance Pretty Assign where
 data AssignOp
     = Equals      -- ^ @=@
     | PlusEquals  -- ^ @+=@
-    deriving (Eq, Ord, Read, Show, Bounded, Enum)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Bounded, Enum)
 
 instance Operator AssignOp where
     operatorTable = zip [Equals, PlusEquals] ["=", "+="]
@@ -335,7 +337,7 @@ data RValue
     = RValue Word
       -- | An array assignment, as @(subscript, word)@ pairs.
     | RArray [(Maybe Word, Word)]
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty RValue where
     pretty (RValue w)  = pretty w

--- a/src/Language/Bash/Word.hs
+++ b/src/Language/Bash/Word.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-    FlexibleInstances
+    DeriveDataTypeable
+  , FlexibleInstances
   , OverloadedStrings
   , RecordWildCards
   , TypeSynonymInstances
@@ -25,7 +26,9 @@ module Language.Bash.Word
 
 import Prelude hiding (Word)
 
+import           Data.Data        (Data)
 import qualified Data.String
+import           Data.Typeable    (Typeable)
 import           Text.PrettyPrint
 
 import           Language.Bash.Operator
@@ -62,7 +65,7 @@ data Span
     | CommandSubst String
       -- | A process substitution.
     | ProcessSubst ProcessSubstOp String
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Span where
     pretty (Char c)           = char c
@@ -81,7 +84,7 @@ instance Pretty Span where
 
 -- | A parameter name an optional subscript.
 data Parameter = Parameter String (Maybe Word)
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 instance Pretty Parameter where
     pretty (Parameter s sub) = text s <> subscript sub
@@ -160,7 +163,7 @@ data ParamSubst
         , convertAll        :: Bool
         , pattern           :: Word
         }
-    deriving (Eq, Read, Show)
+    deriving (Data, Eq, Read, Show, Typeable)
 
 prettyParameter :: Bool -> Parameter -> Doc -> Doc
 prettyParameter bang param suffix =
@@ -203,7 +206,7 @@ data AltOp
     | AltAssign   -- ^ '=', ':='
     | AltError    -- ^ '?', ':?'
     | AltReplace  -- ^ '+', ':+'
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator AltOp where
     operatorTable = zip [minBound .. maxBound] ["-", "=", "?", "+"]
@@ -215,7 +218,7 @@ instance Pretty AltOp where
 data LetterCaseOp
     = ToLower
     | ToUpper
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator LetterCaseOp where
     operatorTable = zip [ToLower, ToUpper] [",", "^"]
@@ -227,7 +230,7 @@ instance Pretty LetterCaseOp where
 data Direction
     = Front
     | Back
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Pretty Direction where
     pretty Front = "#"
@@ -237,7 +240,7 @@ instance Pretty Direction where
 data ProcessSubstOp
     = ProcessIn   -- ^ @\<@
     | ProcessOut  -- ^ @\>@
-    deriving (Eq, Ord, Read, Show, Enum, Bounded)
+    deriving (Data, Eq, Ord, Read, Show, Typeable, Enum, Bounded)
 
 instance Operator ProcessSubstOp where
     operatorTable = zip [ProcessIn, ProcessOut] ["<", ">"]

--- a/src/Language/Bash/Word.hs
+++ b/src/Language/Bash/Word.hs
@@ -23,6 +23,8 @@ module Language.Bash.Word
     , unquote
     ) where
 
+import Prelude hiding (Word)
+
 import qualified Data.String
 import           Text.PrettyPrint
 


### PR DESCRIPTION
These commits are somewhat separable; the first two came from me trying to figure out why this guy wouldn't `cabal install` for me under GHC 7.10, and the last came from me wanting to use uniplate with the Bash syntax tree without twenty-seven `deriving instance` standalones in my code.

If for any reason you'd prefer I do something different than what I've done here, I'd be happy to oblige. I'm still fairly inexperienced in Haskell and not very opinionated about how things ought to be done yet.