### PR TITLE
Support more GHC versions, travis.ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,85 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.1
+      compiler: ": #GHC 7.10.1"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      compiler: ": #GHC 7.10.2"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 language-bash
 -------------
 
+[![Build Status](https://travis-ci.org/knrafto/language-bash.svg)](https://travis-ci.org/knrafto/language-bash)
+
 A library for parsing and pretty-printing Bash shell scripts.

--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -10,6 +10,7 @@ build-type:         Simple
 cabal-version:      >= 1.8
 homepage:           http://github.com/knrafto/language-bash/
 bug-reports:        http://github.com/knrafto/language-bash/issues
+tested-with:        GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2
 synopsis:           Parsing and pretty-printing Bash shell scripts
 description:
     A library for parsing, pretty-printing, and manipulating
@@ -41,7 +42,7 @@ library
     Language.Bash.Parse.Internal
 
   build-depends:
-    base         >= 4.8 && < 5,
+    base         >= 4.6 && < 5,
     parsec       >= 3.0 && < 4.0,
     pretty       >= 1.0 && < 2.0,
     transformers >= 0.2 && < 0.5

--- a/src/Language/Bash/Cond.hs
+++ b/src/Language/Bash/Cond.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveFoldable
+  , CPP
   , DeriveFunctor
   , DeriveTraversable
   , OverloadedStrings
@@ -21,6 +22,11 @@ import Data.Typeable          (Typeable)
 import Text.Parsec            hiding ((<|>), token)
 import Text.Parsec.Expr       hiding (Operator)
 import Text.PrettyPrint       hiding (parens)
+
+#if __GLASGOW_HASKELL__ < 710
+import Data.Foldable (Foldable)
+import Data.Traversable (Traversable)
+#endif
 
 import Language.Bash.Operator
 import Language.Bash.Pretty

--- a/src/Language/Bash/Expand.hs
+++ b/src/Language/Bash/Expand.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, PatternGuards #-}
+{-# LANGUAGE OverloadedStrings, PatternGuards, CPP #-}
 -- | Shell expansions.
 module Language.Bash.Expand
     ( braceExpand
@@ -7,7 +7,11 @@ module Language.Bash.Expand
     , splitWord
     ) where
 
+#if __GLASGOW_HASKELL__ >= 710
 import Prelude hiding (Word)
+#else
+import Data.Traversable (traverse)
+#endif
 
 import Control.Applicative
 import Control.Monad

--- a/src/Language/Bash/Parse/Internal.hs
+++ b/src/Language/Bash/Parse/Internal.hs
@@ -2,6 +2,7 @@
     FlexibleContexts
   , FlexibleInstances
   , LambdaCase
+  , CPP
   , MultiParamTypeClasses
   , OverloadedStrings
   , PatternGuards
@@ -36,7 +37,9 @@ module Language.Bash.Parse.Internal
     , heredocWord
     ) where
 
+#if __GLASGOW_HASKELL__ >= 710
 import Prelude hiding (Word)
+#endif
 
 import           Control.Applicative
 import           Control.Monad

--- a/src/Language/Bash/Parse/Word.hs
+++ b/src/Language/Bash/Parse/Word.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts, RecordWildCards, CPP #-}
 -- | Word-level parsers.
 module Language.Bash.Parse.Word
     ( skipSpace
@@ -11,7 +11,9 @@ module Language.Bash.Parse.Word
     , operator
     ) where
 
+#if __GLASGOW_HASKELL__ >= 710
 import Prelude hiding (Word)
+#endif
 
 import           Control.Applicative
 import           Control.Monad

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable, OverloadedStrings, RecordWildCards, CPP #-}
 -- | Shell script types.
 module Language.Bash.Syntax
     (
@@ -25,7 +25,9 @@ module Language.Bash.Syntax
     , RValue(..)
     ) where
 
+#if __GLASGOW_HASKELL__ >= 710
 import Prelude hiding (Word)
+#endif
 
 import Data.Data        (Data)
 import Data.Typeable    (Typeable)

--- a/src/Language/Bash/Word.hs
+++ b/src/Language/Bash/Word.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , FlexibleInstances
+  , CPP
   , OverloadedStrings
   , RecordWildCards
   , TypeSynonymInstances
@@ -24,7 +25,9 @@ module Language.Bash.Word
     , unquote
     ) where
 
+#if __GLASGOW_HASKELL__ >= 710
 import Prelude hiding (Word)
+#endif
 
 import           Data.Data        (Data)
 import qualified Data.String

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -24,7 +24,7 @@ braceExpr = concat <$> listOf charset
 
 expandWithBash :: String -> IO String
 expandWithBash str = do
-    expn <- readProcess "/bin/bash" ["-c", "echo " ++ str] ""
+    expn <- readProcess "/usr/bin/env" ["bash", "-c", "echo " ++ str] ""
     return $ filter (`notElem` "\r\n") expn
 
 testExpand :: String -> [String]


### PR DESCRIPTION
Travis build for this patch: https://travis-ci.org/jb55/language-bash/builds/96646853

* add travis
* support more ghc versions
* relax base bound
* fix traverse/foldable imports
* fix tests on nixos

To get travis badge working, you need to turn on travis integration for this repo on your account here: 

https://travis-ci.org/profile/knrafto