### PR TITLE
List assignments

### DIFF
--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -61,4 +61,5 @@ test-suite tests
     process,
     QuickCheck,
     tasty,
-    tasty-quickcheck
+    tasty-quickcheck,
+    tasty-hunit

--- a/src/Language/Bash/Parse.hs
+++ b/src/Language/Bash/Parse.hs
@@ -18,7 +18,6 @@ import           Text.Parsec.Prim             hiding (parse, (<|>))
 import qualified Language.Bash.Cond           as Cond
 import           Language.Bash.Operator
 import           Language.Bash.Parse.Internal
-import           Language.Bash.Pretty
 import           Language.Bash.Syntax
 import           Language.Bash.Word           (fromString, unquote)
 
@@ -384,13 +383,12 @@ functionDef = functionDef2
           <?> "function definition"
   where
     functionDef1 = FunctionDef
-               <$> try (word "function" *> (prettyText <$> anyWord)
+               <$> try (word "function" *> name
                         <* optional functionParens <* newlineList)
                <*> functionBody
 
     functionDef2 = FunctionDef
-               <$> try ((prettyText <$> unreservedWord)
-                        <*  functionParens <* newlineList)
+               <$> try (name <* functionParens <* newlineList)
                <*> functionBody
 
     functionParens = operator "(" <* operator ")"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,17 +1,22 @@
 module Main (main) where
 
-import Control.Applicative
-import System.Process           (readProcess)
-import Test.QuickCheck
-import Test.QuickCheck.Monadic
-import Test.Tasty
-import Test.Tasty.QuickCheck
-import Text.Parsec              (parse)
+import           Control.Applicative
+import           System.Process           (readProcess)
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic  as QCM
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Tasty.HUnit
+import           Text.Parsec              (parse)
 
-import Language.Bash.Expand     (braceExpand)
-import Language.Bash.Parse.Word (word)
-import Language.Bash.Word       (unquote)
-
+import qualified Language.Bash.Parse      as Parse
+import           Language.Bash.Syntax
+import qualified Language.Bash.Cond       as Cond
+import           Language.Bash.Word
+import           Language.Bash.Expand     (braceExpand)
+import           Language.Bash.Parse.Word (word)
+import           Language.Bash.Word       (unquote)
+import qualified Language.Bash.Pretty     as Pretty
 -- TODO sequence
 braceExpr :: Gen String
 braceExpr = concat <$> listOf charset
@@ -37,10 +42,34 @@ prop_expandsLikeBash :: Property
 prop_expandsLikeBash = monadicIO $ forAllM braceExpr $ \str -> do
     bash <- run $ expandWithBash str
     let check = unwords . filter (not . null) $ testExpand str
-    assert (bash == check)
+    QCM.assert (bash == check)
+
+properties :: TestTree
+properties = testGroup "Properties" [testProperty "brace expansion" prop_expandsLikeBash]
+
+testTest = testCase "testTest" $
+           case Cond.parseTestExpr ["!", "-e", "\"asd\""] of
+             { Left err -> assertFailure ("parseError: " ++ (show err))
+             ; Right ans -> (Cond.Not (Cond.Unary Cond.FileExists "\"asd\"")) @=? ans
+             }
+
+testDoubleQuoted = testCase "testDoubleQuoted" $
+           case Parse.parse "source" "\"$(ls)\"" of
+             { Left err -> assertFailure ("parseError: " ++ (show err))
+             ; Right ans -> (List [Statement (Last (Pipeline {timed = False, timedPosix = False, inverted = False, commands = [Command (SimpleCommand [] [[Double [CommandSubst "ls"]]]) []]})) Sequential]) @=? ans
+             }
+
+testEmptyArrayAssignment = testCase "testEmptyArrayAssignment" $
+           case Parse.parse "source" "arguments=()\n" of
+             { Left err -> assertFailure ("parseError: " ++ (show err))
+             ; Right ans -> (List [Statement (Last (Pipeline {timed = False, timedPosix = False, inverted = False, commands = [Command (SimpleCommand [Assign (Parameter "arguments" Nothing) Equals (RArray [])] []) []]})) Sequential]) @=? ans
+             }
+
+unittests :: TestTree
+unittests = testGroup "Unit tests" [testTest, testDoubleQuoted, testEmptyArrayAssignment]
 
 tests :: TestTree
-tests = testProperty "brace expansion" prop_expandsLikeBash
+tests = testGroup "Tests" [properties, unittests]
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
Assignments where the rvalue was an empty array didn't work. This adds some unit tests, including a test that that works.

I'm not sure if the fix is correct, but I tried lots of things to figure this out. Basically, the grammar for Assign is correct, but the operators stuff has higher precedence. If you have a better fix I'm happy to implement it.