### PR TITLE
Grab bag of minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 cabal.sandbox.config
 *.o
 *.hi
+.stack-work

--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -62,4 +62,5 @@ test-suite tests
     QuickCheck,
     tasty,
     tasty-quickcheck,
-    tasty-hunit
+    tasty-hunit,
+    tasty-expected-failure

--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -45,7 +45,7 @@ library
     base         >= 4.6 && < 5,
     parsec       >= 3.0 && < 4.0,
     pretty       >= 1.0 && < 2.0,
-    transformers >= 0.2 && < 0.5
+    transformers >= 0.2 && < 0.6
 
   ghc-options: -Wall
 

--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -1,11 +1,11 @@
 name:               language-bash
-version:            0.6.1
+version:            0.6.2
 category:           Language
 license:            BSD3
 license-file:       LICENSE
 author:             Kyle Raftogianis
 maintainer:         Kyle Raftogianis <kylerafto@gmail.com>
-copyright:          Copyright (c) 2013-2015 Kyle Raftogianis
+copyright:          Copyright (c) 2013-2016 Kyle Raftogianis
 build-type:         Simple
 cabal-version:      >= 1.8
 homepage:           http://github.com/knrafto/language-bash/

--- a/src/Language/Bash/Parse.hs
+++ b/src/Language/Bash/Parse.hs
@@ -119,8 +119,8 @@ redir = normalRedir
             heredocDelimQuoted = fromString heredocDelim /= w
         h <- heredoc (heredocOp == HereStrip) heredocDelim
         hereDocument <- if heredocDelimQuoted
-                        then heredocWord h
-                        else return (fromString h)
+                        then return (fromString h)
+                        else heredocWord h
         return Heredoc{..}
 
     redirOperator   = selectOperator operator <?> "redirection operator"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-6.18

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -23,7 +23,7 @@ import           Language.Bash.Parse.Word (word)
 braceExpr :: Gen String
 braceExpr = concat <$> listOf charset
   where
-    charset = oneof $
+    charset = oneof
         [ elements ["{", ",", "}"]
         , elements ["\\ ", "\\{", "\\,", "\\}"]
         , (:[]) <$> elements ['a'..'z']
@@ -52,11 +52,11 @@ properties = testGroup "Properties" [testProperty "brace expansion" prop_expands
 testMatches :: (Eq a, Show a) => TestName -> Either Text.Parsec.Error.ParseError a -> a -> TestTree
 testMatches name parsed expected = testCase name $
            case parsed of
-               Left err -> assertFailure $ "parseError: " ++ (show err)
+               Left err -> assertFailure $ "parseError: " ++ show err
                Right ans -> expected @=? ans
 
 wrapCommand :: Command -> List
-wrapCommand c = (List [Statement (Last (Pipeline {timed = False, timedPosix = False, inverted = False, commands = [c]})) Sequential])
+wrapCommand c = List [Statement (Last Pipeline {timed = False, timedPosix = False, inverted = False, commands = [c]}) Sequential]
 
 tp :: TestName -> Command -> TestTree
 tp source expected = testMatches source


### PR DESCRIPTION
This is a grab bag of minor fixes that things slightly easier on me:

- expand range of transformers allowed (I'm trying to get to GHC 8 via stack/lts-7)
- unit tests are now much easier to add
- add trivial stack.yml
- add test cases which are expected and known to fail. A sort of TODO list (I plan on working on these, and it's a nice place to add future ones)
- bump version number and copyright year
- clean up warnings and linter warnings in tests
- bug fix+tests: heredoc logic is wrong

I can split these into multiple PRs or cut out commits that you don't like: let me know what you prefer!