### PR TITLE
Remove IsString instance

### DIFF
--- a/src/Language/Bash/Expand.hs
+++ b/src/Language/Bash/Expand.hs
@@ -113,7 +113,7 @@ braceExpand = parseUnsafe "braceExpand" start
     start = prefix <$> string "{}" <*> expr ""
         </> expr ""
 
-    expr delims = foldr ($) [""] <$> many (exprPart delims)
+    expr delims = foldr ($) [[]] <$> many (exprPart delims)
 
     exprPart delims = cross <$ char '{' <*> brace delims <* char '}'
                   </> prefix <$> emptyBrace
@@ -121,7 +121,7 @@ braceExpand = parseUnsafe "braceExpand" start
 
     brace delims = concat <$> braceParts delims
                </> sequenceExpand
-               </> map (\s -> "{" ++ s ++ "}") <$> expr ",}"
+               </> map (\s -> stringToWord "{" ++ s ++ stringToWord "}") <$> expr ",}"
 
     -- The first part of the outermost brace expression is not delimited by
     -- a close brace.
@@ -145,7 +145,7 @@ braceExpand = parseUnsafe "braceExpand" start
         b   <- string ".." *> sequencePart
         c   <- optional (string ".." *> sequencePart)
         inc <- traverse readNumber c
-        map fromString <$> (numExpand a b inc <|> charExpand a b inc)
+        map stringToWord <$> (numExpand a b inc <|> charExpand a b inc)
       where
         sequencePart = many1 (satisfy' isAlphaNum)
 

--- a/src/Language/Bash/Parse/Internal.hs
+++ b/src/Language/Bash/Parse/Internal.hs
@@ -4,7 +4,6 @@
   , LambdaCase
   , CPP
   , MultiParamTypeClasses
-  , OverloadedStrings
   , PatternGuards
   , RecordWildCards
   #-}
@@ -137,7 +136,7 @@ satisfying a p = try $ do
 
 -- | Shell reserved words.
 reservedWords :: [Word]
-reservedWords =
+reservedWords = map stringToWord
     [ "!", "[[", "]]", "{", "}"
     , "if", "then", "else", "elif", "fi"
     , "case", "esac", "for", "select", "while", "until"
@@ -147,7 +146,7 @@ reservedWords =
 -- | Shell assignment builtins. These builtins can take assignments as
 -- arguments.
 assignBuiltins :: [Word]
-assignBuiltins =
+assignBuiltins = map stringToWord
     [ "alias", "declare", "export", "eval"
     , "let", "local", "readonly", "typeset"
     ]
@@ -175,8 +174,8 @@ anyWord :: Monad m => ParsecT D u m Word
 anyWord = try (rat _anyWord) <?> "word"
 
 -- | Parse the given word.
-word :: Monad m => Word -> ParsecT D u m Word
-word w = anyWord `satisfying` (== w) <?> prettyText w
+word :: Monad m => String -> ParsecT D u m Word
+word w = anyWord `satisfying` (== stringToWord w) <?> prettyText w
 
 -- | Parse a reversed word.
 reservedWord :: Monad m => ParsecT D u m Word

--- a/src/Language/Bash/Word.hs
+++ b/src/Language/Bash/Word.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE
     DeriveDataTypeable
-  , FlexibleInstances
   , CPP
   , OverloadedStrings
   , RecordWildCards
@@ -8,7 +7,7 @@
   #-}
 -- | Bash words and substitutions.
 module Language.Bash.Word
-    ( 
+    (
       -- * Words
       Word
     , Span(..)
@@ -21,7 +20,7 @@ module Language.Bash.Word
       -- * Process
     , ProcessSubstOp(..)
       -- * Manipulation
-    , fromString
+    , stringToWord
     , unquote
     ) where
 
@@ -30,7 +29,6 @@ import Prelude hiding (Word)
 #endif
 
 import           Data.Data        (Data)
-import qualified Data.String
 import           Data.Typeable    (Typeable)
 import           Text.PrettyPrint
 
@@ -39,9 +37,6 @@ import           Language.Bash.Pretty
 
 -- | A Bash word, broken up into logical spans.
 type Word = [Span]
-
-instance Data.String.IsString Word where
-    fromString = fromString
 
 -- | An individual unit of a word.
 data Span
@@ -252,8 +247,8 @@ instance Pretty ProcessSubstOp where
     pretty = prettyOperator
 
 -- | Convert a string to an unquoted word.
-fromString :: String -> Word
-fromString = map Char
+stringToWord :: String -> Word
+stringToWord = map Char
 
 -- | Remove all quoting characters from a word.
 unquote :: Word -> String

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-6.18
+resolver: lts-8.6


### PR DESCRIPTION
This is necessary, as otherwise you get overlapping instances with GHC 8

I also renamed `fromString :: String -> Word` to `stringToWord`, because I think it's confusing to have both a local `fromString` along with `Data.String.fromString`.  In particular, on first sight of the instance, it looked a lot like an infinite loop!

```
instance Data.String.IsString Word where		
    fromString = fromString
```