### PR TITLE
Build on GHC 9.4.8 and 9.6.6; remove compilation warnings

### DIFF
--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -10,7 +10,7 @@ build-type:         Simple
 cabal-version:      >= 1.8
 homepage:           http://github.com/knrafto/language-bash/
 bug-reports:        http://github.com/knrafto/language-bash/issues
-tested-with:        GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.2, GHC == 8.4.3, GHC == 8.8.3
+tested-with:        GHC == 8.4.3, GHC == 8.8.3, GHC == 9.4.8, GHC == 9.6.6
 synopsis:           Parsing and pretty-printing Bash shell scripts
 description:
     A library for parsing, pretty-printing, and manipulating
@@ -45,10 +45,16 @@ library
     Language.Bash.Parse.Internal
 
   build-depends:
-    base          >= 4.6 && < 5,
+    -- Notes on version bounds:
+    --
+    -- * base-4.11 is the first where Prelude re-exports Semigroup(s). This
+    --   version of base is bundled with 8.4.1.
+    -- * prettyprinter-1.7.0 is the first version where Prettyprinter module
+    --   hierarchy was introduced.
+    base          >= 4.11 && < 5,
     parsec        >= 3.0 && < 4.0,
-    prettyprinter >= 1.2 && < 2.0,
-    transformers  >= 0.2 && < 0.6
+    prettyprinter >= 1.7 && < 2.0,
+    transformers  >= 0.2 && < 0.7
 
   ghc-options: -Wall
 

--- a/src/Language/Bash/Cond.hs
+++ b/src/Language/Bash/Cond.hs
@@ -22,7 +22,7 @@ import Data.Typeable          (Typeable)
 import GHC.Generics           (Generic)
 import Text.Parsec            hiding ((<|>), token)
 import Text.Parsec.Expr       hiding (Operator)
-import Data.Text.Prettyprint.Doc (Pretty(..), (<+>))
+import Prettyprinter          (Pretty(..), (<+>))
 
 import Language.Bash.Operator
 

--- a/src/Language/Bash/Expand.hs
+++ b/src/Language/Bash/Expand.hs
@@ -12,11 +12,10 @@ import Prelude hiding (Word)
 import Control.Applicative
 import Control.Monad
 import Data.Char
-import Data.Monoid            ((<>))
 import Text.Parsec.Combinator hiding (optional, manyTill)
 import Text.Parsec.Prim       hiding ((<|>), many, token)
 import Text.Parsec.String     ()
-import Data.Text.Prettyprint.Doc (Pretty(..))
+import Prettyprinter          (Pretty(..))
 
 import Language.Bash.Pretty
 import Language.Bash.Word     hiding (prefix)

--- a/src/Language/Bash/Operator.hs
+++ b/src/Language/Bash/Operator.hs
@@ -6,9 +6,9 @@ module Language.Bash.Operator
     , prettyOperator
     ) where
 
-import Control.Applicative
-import Data.Foldable
-import Data.Text.Prettyprint.Doc (Doc, pretty)
+import Control.Applicative (Alternative)
+import Data.Foldable (asum)
+import Prettyprinter (Doc, pretty)
 
 -- | String operators.
 class Eq a => Operator a where

--- a/src/Language/Bash/Pretty.hs
+++ b/src/Language/Bash/Pretty.hs
@@ -2,9 +2,9 @@
 -- used by the Bash builtin @declare -f@.
 module Language.Bash.Pretty where
 
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Internal
-import Data.Text.Prettyprint.Doc.Render.String
+import Prettyprinter
+import Prettyprinter.Internal.Type (Doc(Empty))
+import Prettyprinter.Render.String (renderString)
 
 -- | @x $+$ y@ concatenates @x@ and @y@ with a 'line' in between
 ($+$) :: Doc ann -> Doc ann -> Doc ann

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -29,11 +29,10 @@ import Prelude hiding (Word)
 
 import Data.Data        (Data)
 import Data.List        (intersperse)
-import Data.Semigroup   (Semigroup(..))
 import Data.Typeable    (Typeable)
 import GHC.Generics     (Generic)
-import Data.Text.Prettyprint.Doc (Doc, Pretty(..), (<+>), hardline, hcat, hsep, indent, nest, nesting, punctuate, vcat)
-import Data.Text.Prettyprint.Doc.Internal (Doc(Empty))
+import Prettyprinter    (Doc, Pretty(..), (<+>), hardline, hcat, hsep, indent, nest, nesting, punctuate, vcat)
+import Prettyprinter.Internal.Type (Doc(Empty))
 
 import Language.Bash.Cond     (CondExpr)
 import Language.Bash.Operator
@@ -125,7 +124,7 @@ instance Pretty Command where
 instance ToBashDoc Command where
     toBashDoc (Command c rs) = BashDoc mempty (pretty c <++> pretty rs) (prettyHeredocs $ filter isHeredoc rs)
         where
-            isHeredoc Heredoc{..} = True
+            isHeredoc Heredoc{} = True
             isHeredoc _ = False
 
 -- | A Bash command.

--- a/src/Language/Bash/Word.hs
+++ b/src/Language/Bash/Word.hs
@@ -29,11 +29,10 @@ module Language.Bash.Word
 import Prelude hiding (Word)
 
 import           Data.Data        (Data)
-import           Data.Monoid      ((<>))
 import           Data.Typeable    (Typeable)
 import           GHC.Generics     (Generic)
-import           Data.Text.Prettyprint.Doc (Doc, Pretty(..), hcat, hsep, layoutCompact)
-import           Data.Text.Prettyprint.Doc.Render.String (renderString)
+import           Prettyprinter    (Doc, Pretty(..), hcat, hsep, layoutCompact)
+import           Prettyprinter.Render.String (renderString)
 
 import           Language.Bash.Operator
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
-resolver: lts-15.9
+resolver:
+  # GHC 9.4.8
+# url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  # GHC 9.6.6
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,8 @@
 packages: []
 snapshots:
 - completed:
-    size: 492027
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/9.yaml
-    sha256: 11394dc975e96c2fea90f7f2b3229630d46351a092ebcec78f0a56403930b429
-  original: lts-15.9
+    sha256: 795b7a893148a42f09956611a0fa1139293fe6ef934d053468d8e53e3e013390
+    size: 719577
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml
+  original:
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/30.yaml


### PR DESCRIPTION
This commit covers the following:

* Change all `Data.Text.Prettyprint` imports to `Prettyprinter` imports.

* Some imports were made explicit to avoid "unnecessary import" warnings.

* Removed explicit imports of definitions that are now in `Prelude`.

* Setting lower bound of `base` to 4.11. It's the first version that re-exports `Semigroup` type class from `Prelude`. As a consequence the package is not buildable on GHC ≤9.4.

* Setting lower bound of `prettyprinter` to 1.7, which introduced the `Prettyprinter` module hierarchy. Later versions deprecated the `Data.Text.Prettyprint` module hierarchy, therefore, switching to the newer hierarchy requires this lower bound.

* Setting upper bound of `transformers` to 0.7. The 0.6.* versions are compatible with this package and no changes needed to be made