### PR TITLE
`Language.Bash.Parse.Builder`: Be more specific when importing stuff

### DIFF
--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -25,7 +25,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: git://github.com/knrafto/language-bash.git
+  location: https://github.com/knrafto/language-bash.git
 
 library
   default-language: Haskell2010
@@ -50,10 +50,11 @@ library
     --
     -- * base-4.11 is the first where Prelude re-exports Semigroup(s). This
     --   version of base is bundled with 8.4.1.
+    -- * parsec-3.1.17.0 is the first where Text.Parsec.Prim.many1 is defined.
     -- * prettyprinter-1.7.0 is the first version where Prettyprinter module
     --   hierarchy was introduced.
     base          >= 4.11 && < 5,
-    parsec        >= 3.0 && < 4.0,
+    parsec        >= 3.1.17 && < 4.0,
     prettyprinter >= 1.7 && < 2.0,
     transformers  >= 0.2 && < 0.7
 

--- a/src/Language/Bash/Parse/Builder.hs
+++ b/src/Language/Bash/Parse/Builder.hs
@@ -25,11 +25,11 @@ module Language.Bash.Parse.Builder
 
 import           Prelude                hiding (span)
 
-import           Control.Applicative    hiding (many)
-import qualified Control.Applicative    as Applicative
-import           Data.Monoid
+import           Control.Applicative    ((<|>))
+import           Data.Monoid            (Endo (..))
+import           Text.Parsec            (ParsecT, Stream)
 import qualified Text.Parsec.Char       as P
-import           Text.Parsec.Prim       hiding ((<|>), many)
+import qualified Text.Parsec.Prim       as P
 
 infixr 4 <+>
 
@@ -53,12 +53,12 @@ toString = flip appEndo ""
 (<+>) = liftA2 mappend
 
 -- | Concat zero or more monoidal results.
-many :: (Alternative f, Monoid a) => f a -> f a
-many = fmap mconcat . Applicative.many
+many :: Monoid a => ParsecT s u m a -> ParsecT s u m a
+many = fmap mconcat . P.many
 
 -- | Concat one or more monoidal results.
-many1 :: (Alternative f, Monoid a) => f a -> f a
-many1 = fmap mconcat . Applicative.some
+many1 :: Monoid a => ParsecT s u m a -> ParsecT s u m a
+many1 = fmap mconcat . P.many1
 
 -- | 'Builder' version of 'P.oneOf'.
 oneOf :: Stream s m Char => [Char] -> ParsecT s u m Builder


### PR DESCRIPTION
We require parsec >=3.1.17 since we use `Text.Parsec.Prim.many1` internally.

Fixes #43 