### PR TITLE
Fix pretty printing of Here Documents without trailing newline

### DIFF
--- a/language-bash.cabal
+++ b/language-bash.cabal
@@ -20,7 +20,6 @@ tested-with:        GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC
 extra-source-files:
   README.md
   tests/pretty/*.golden
-  tests/pretty/*.out
   tests/pretty/*.sh
 
 source-repository head

--- a/src/Language/Bash/Parse/Word.hs
+++ b/src/Language/Bash/Parse/Word.hs
@@ -48,7 +48,7 @@ upTo m p = go m
 upTo1 :: Alternative f => Int -> f a -> f [a]
 upTo1 n p = (:) <$> p <*> upTo (n - 1) p
 
--- | Parse a span until a delimeter.
+-- | Parse a span until a delimiter.
 spans
     :: Stream s m Char
     => [Char]              -- ^ Delimiters

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, OverloadedStrings, RecordWildCards, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, GeneralizedNewtypeDeriving, OverloadedStrings, RecordWildCards, DeriveGeneric #-}
 -- | Shell script types.
 module Language.Bash.Syntax
     (
@@ -320,7 +320,7 @@ instance Pretty HeredocOp where
 
 -- | A compound list of statements.
 newtype List = List [Statement]
-    deriving (Data, Eq, Read, Show, Typeable, Generic)
+    deriving (Data, Eq, Monoid, Read, Semigroup, Show, Typeable, Generic)
 
 instance Pretty List where
     pretty (List as) = pretty as

--- a/src/Language/Bash/Syntax.hs
+++ b/src/Language/Bash/Syntax.hs
@@ -87,8 +87,13 @@ prettyHeredocs :: [Redir] -> Doc ann
 prettyHeredocs [] = mempty
 prettyHeredocs rs = mconcat $ intersperse hardline $ map prettyHeredoc rs
     where
-        prettyHeredoc Heredoc{..} = pretty hereDocument <> pretty heredocDelim
+        prettyHeredoc Heredoc{..} = pretty (ensureTrailingNewline hereDocument) <> pretty heredocDelim
         prettyHeredoc _ = mempty
+
+        ensureTrailingNewline [] = []
+        ensureTrailingNewline xs
+            | last xs == Char '\n' = xs
+            | otherwise = xs ++ [Char '\n']
 
 -- | Indent by 4 columns.
 indent' :: Doc ann -> Doc ann

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -188,6 +188,32 @@ unittests = testGroup "Unit tests"
                   heredocDelim = "EOF",
                   heredocDelimQuoted = False,
                   hereDocument = stringToWord "comment\n"}])
+  , testGroup "Issue #23 regression tests"
+    [ testCase "Empty document" $ do
+          let list = wrapCommand $ Command
+                  (SimpleCommand [] [stringToWord "command"])
+                  [ Heredoc
+                      { heredocOp = Here
+                      , heredocDelim = "EOF"
+                      , heredocDelimQuoted = False
+                      , hereDocument = []
+                      }
+                  ]
+              expected = "command <<EOF;\nEOF"
+          expected @=? prettyText list
+    , testCase "Non-empty document" $ do
+          let list = wrapCommand $ Command
+                  (SimpleCommand [] [stringToWord "command"])
+                  [ Heredoc
+                      { heredocOp = Here
+                      , heredocDelim = "EOF"
+                      , heredocDelimQuoted = False
+                      , hereDocument = stringToWord "here document"
+                      }
+                  ]
+              expected = "command <<EOF;\nhere document\nEOF"
+          expected @=? prettyText list
+    ]
   ]
 
 failingtests :: TestTree


### PR DESCRIPTION
Fixes #23 

I also added the `Semigroup` and `Monoid` instances I asked for in #25 since it don't want to open too many PRs:
Fixes #25 